### PR TITLE
Fix IndexError when lookup_symbol() can't find a match

### DIFF
--- a/intuition/data/remote.py
+++ b/intuition/data/remote.py
@@ -237,8 +237,10 @@ def lookup_symbol(company):
     infos = {}
     request = requests.get(finance_urls['info_lookup'].format(company))
     if request.ok:
-        infos = json.loads(request.text[39:-1])["ResultSet"]["Result"][0]
-        infos["market"] = infos.pop("exchDisp")
-        infos["type"] = infos.pop("typeDisp")
+        result = json.loads(request.text[39:-1])["ResultSet"]["Result"]
+        if result:
+            infos = result[0]
+            infos["market"] = infos.pop("exchDisp")
+            infos["type"] = infos.pop("typeDisp")
 
     return infos


### PR DESCRIPTION
I was playing with intuition.data.remote and got IndexError exceptions when calling lookup_symbol() with a string that couldn't be matched with an actual symbol name. Here is a quick fix.

How to reproduce on the develop branch:

``` python
import intuition.data.remote as r

r.lookup_symbol("Carrouf")
```
